### PR TITLE
G3.2. Настройка запуска e2e тестов

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "react-dom": "19.1.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.56.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "e2e": "pnpm -r e2e"
   },
   "devDependencies": {
-    "@playwright/test": "^1.56.0",
     "eslint": "^9.37.0",
     "prettier": "^3.6.2",
     "typescript": "^5.9.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     devDependencies:
-      '@playwright/test':
-        specifier: ^1.56.0
-        version: 1.56.0
       eslint:
         specifier: ^9.37.0
         version: 9.37.0(jiti@2.6.1)


### PR DESCRIPTION
# G3.2. Настройка запуска e2e тестов


## Связанные задачи
- Closes #15

## Тип изменений
- [ ] Bug fix
- [X] Feature
- [ ] Refactor / Tech debt
- [ ] Docs / Chore
- [ ] CI/CD

## Что сделано


- Создана простая навигация между страничками с помощью next.js и e2e тесты для ее проверки используя Playwright


## Как проверить локально
- `pnpm install`
- `pnpm exec playwright install --with-deps`
- `pnpm -r --filter @assetpredict/web dev`
- `pnpm -r --filter @assetpredict/web e2e` (после поднятия сервера)




