### PR TITLE
fix pnpm start script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "pnpm -r --parallel dev",
     "build": "pnpm -r build",
-    "start": "pnpm --filter web serve",
+    "start": "pnpm -r start",
     "api:dev": "pnpm --filter @assetpredict/api dev",
     "api:build": "pnpm --filter @assetpredict/api build",
     "api:start": "pnpm --filter @assetpredict/api start",


### PR DESCRIPTION

## Тип изменений
- [X] Bug fix
- [ ] Feature
- [ ] Refactor / Tech debt
- [ ] Docs / Chore
- [ ] CI/CD

## Что сделано
- `pnpm start` из корня теперь запускает и web, и api. Раньше запускался только web как статическое приложение

## Как проверить локально
1. `pnpm i`
2. `pnpm build`, `pnpm start`
3. Открыть `http://localhost:3000`