### PR TITLE
Timeseries Slice Fix

### DIFF
--- a/apps/web/src/entities/timeseries/model/timeseriesSlice.ts
+++ b/apps/web/src/entities/timeseries/model/timeseriesSlice.ts
@@ -1,7 +1,11 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '@/shared/store';
 import type { Bar } from '@shared/types/market';
-import type { MarketDataProvider, MarketTimeframe } from '@/config/market';
+import {
+  DEFAULT_LIMIT,
+  type MarketDataProvider,
+  type MarketTimeframe,
+} from '@/config/market';
 import type { TimeseriesCacheKey } from '@/shared/lib/cacheKey';
 
 export type TimeseriesKey = TimeseriesCacheKey;
@@ -10,7 +14,8 @@ export const buildTimeseriesKey = (
   provider: MarketDataProvider,
   symbol: string,
   timeframe: MarketTimeframe,
-): TimeseriesKey => `${provider}:${symbol}:${timeframe}`;
+  limit: number = DEFAULT_LIMIT,
+): TimeseriesKey => `${provider}:${symbol}:${timeframe}:${limit}`;
 
 interface TimeseriesEntry {
   bars: Bar[];
@@ -36,7 +41,8 @@ interface TimeseriesRequestedPayload {
 interface TimeseriesReceivedPayload {
   key: TimeseriesKey;
   bars: Bar[];
-  fetchedAt: string;
+  // optional for backward-compatibility: we normalize to ISO in reducer
+  fetchedAt?: string;
 }
 
 interface TimeseriesFailedPayload {
@@ -61,7 +67,9 @@ const timeseriesSlice = createSlice({
       state,
       action: PayloadAction<TimeseriesReceivedPayload>,
     ) {
-      const { key, bars, fetchedAt } = action.payload;
+      const { key, bars } = action.payload;
+      // гарантируем единый формат времени в сторе
+      const fetchedAt = new Date().toISOString();
       state.byKey[key] = { bars, fetchedAt };
       state.loadingByKey[key] = false;
       state.errorByKey[key] = null;
@@ -98,6 +106,30 @@ export const timeseriesReducer = timeseriesSlice.reducer;
 
 export const selectTimeseriesByKey = (state: RootState, key: TimeseriesKey) =>
   state.timeseries.byKey[key]?.bars ?? null;
+
+export const selectTimeseriesFetchedAtByKey = (
+  state: RootState,
+  key: TimeseriesKey,
+) => state.timeseries.byKey[key]?.fetchedAt ?? null;
+
+/**
+ * TTL helper на уровне слайса
+ * Если нет данных или fetchedAt некорректен -считаем ряд устаревшим
+ */
+export const isTimeseriesStaleByKey = (
+  state: RootState,
+  key: TimeseriesKey,
+  ttlMs: number,
+  nowMs: number = Date.now(),
+): boolean => {
+  const fetchedAt = state.timeseries.byKey[key]?.fetchedAt;
+  if (!fetchedAt) return true;
+
+  const fetchedMs = Date.parse(fetchedAt);
+  if (!Number.isFinite(fetchedMs)) return true;
+
+  return nowMs - fetchedMs > ttlMs;
+};
 
 export const selectTimeseriesLoadingByKey = (
   state: RootState,


### PR DESCRIPTION
build timeseries key(add limit), new at fetchedAt, add isTimeseriesStaleByKey, edit selectors

## Тип изменений
- [X] Bug fix
- [ ] Feature
- [ ] Refactor / Tech debt
- [ ] Docs / Chore
- [ ] CI/CD

## Что сделано
- Исправлен ключ таймсерии: buildTimeseriesKey теперь включает limit (provider:symbol:timeframe:limit), чтобы стор и запросы не конфликтовали при разных window.

- Унифицировано поле fetchedAt: в timeseriesReceived всегда сохраняется new Date().toISOString() (единый формат, без Date.now() и произвольных строк).

- Добавлен helper/селектор устаревания данных по TTL на уровне слайса: isTimeseriesStaleByKey(state, key, ttlMs, nowMs?).

- Обновлены селекторы (selectors.ts) под новую структуру и TTL-логику.

- Обновлены тесты: фиксируется системное время через fake timers, чтобы стабильно проверять fetchedAt.