### PR TITLE
сделал providers

### DIFF
--- a/apps/web/src/__tests__/features/market-adapter/providers/BinanceProvider.test.ts
+++ b/apps/web/src/__tests__/features/market-adapter/providers/BinanceProvider.test.ts
@@ -1,10 +1,14 @@
 // apps/web/src/__tests__/features/market-adapter/providers/BinanceProvider.test.ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fetchBinanceTimeseries } from '@/features/market-adapter/providers/BinanceProvider';
+import {
+  fetchBinanceTimeseries,
+  searchBinanceSymbols,
+} from '@/features/market-adapter/providers/BinanceProvider';
 
 // хостим мок до vi.mock
-const { mockBinanceInitiate } = vi.hoisted(() => ({
+const { mockBinanceInitiate, mockBinanceSearchInitiate } = vi.hoisted(() => ({
   mockBinanceInitiate: vi.fn(),
+  mockBinanceSearchInitiate: vi.fn(),
 }));
 
 vi.mock('@/shared/api/marketApi', () => ({
@@ -13,6 +17,9 @@ vi.mock('@/shared/api/marketApi', () => ({
     endpoints: {
       getBinanceTimeseries: {
         initiate: (...args: any[]) => mockBinanceInitiate(...args),
+      },
+      searchBinanceSymbols: {
+        initiate: (...args: any[]) => mockBinanceSearchInitiate(...args),
       },
     },
   },
@@ -23,6 +30,7 @@ vi.mock('@/shared/api/marketApi', () => ({
 describe('fetchBinanceTimeseries', () => {
   beforeEach(() => {
     mockBinanceInitiate.mockReset();
+    mockBinanceSearchInitiate.mockReset();
   });
 
   it('вызывает getBinanceTimeseries с корректными параметрами и возвращает данные', async () => {
@@ -59,5 +67,74 @@ describe('fetchBinanceTimeseries', () => {
     expect(mockQueryResult.unwrap).toHaveBeenCalledTimes(1);
     expect(mockQueryResult.unsubscribe).toHaveBeenCalledTimes(1);
     expect(result).toBe(mockData);
+  });
+
+  it('маппит timeframe 7d на binance interval 1w', async () => {
+    const mockDispatch = vi.fn((action: any) => action);
+
+    const params = {
+      symbol: 'BTCUSDT',
+      timeframe: '7d' as const,
+      limit: 10,
+    };
+
+    const mockQueryResult = {
+      unwrap: vi.fn().mockResolvedValue([]),
+      unsubscribe: vi.fn(),
+      abort: vi.fn(),
+    };
+
+    mockBinanceInitiate.mockReturnValue(mockQueryResult);
+
+    await fetchBinanceTimeseries(mockDispatch as any, params);
+
+    expect(mockBinanceInitiate).toHaveBeenCalledWith({
+      symbol: 'BTCUSDT',
+      interval: '1w',
+      limit: 10,
+    });
+  });
+
+  it('абортирует inflight запрос через AbortSignal', async () => {
+    const mockDispatch = vi.fn((action: any) => action);
+    const controller = new AbortController();
+
+    const params = {
+      symbol: 'BTCUSDT',
+      timeframe: '1h' as const,
+      limit: 5,
+    };
+
+    const mockQueryResult = {
+      unwrap: vi.fn().mockResolvedValue([]),
+      unsubscribe: vi.fn(),
+      abort: vi.fn(),
+    };
+
+    mockBinanceInitiate.mockReturnValue(mockQueryResult);
+
+    const promise = fetchBinanceTimeseries(mockDispatch as any, params, {
+      signal: controller.signal,
+    });
+
+    controller.abort();
+    await promise;
+
+    expect(mockQueryResult.abort).toHaveBeenCalledTimes(1);
+    expect(mockQueryResult.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('searchBinanceSymbols сразу отказывает при abort', async () => {
+    const mockDispatch = vi.fn();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      searchBinanceSymbols(mockDispatch as any, 'btc', {
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    expect(mockBinanceSearchInitiate).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/__tests__/features/market-adapter/providers/MockProvider.test.ts
+++ b/apps/web/src/__tests__/features/market-adapter/providers/MockProvider.test.ts
@@ -1,6 +1,9 @@
 // apps/web/src/__tests__/features/market-adapter/providers/MockProvider.test.ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fetchMockTimeseries } from '@/features/market-adapter/providers/MockProvider';
+import {
+  fetchMockTimeseries,
+  searchMockSymbols,
+} from '@/features/market-adapter/providers/MockProvider';
 
 const dispatch = vi.fn() as any;
 
@@ -66,5 +69,31 @@ describe('MockProvider', () => {
     const stepB = b[1][0] - b[0][0];
 
     expect(stepB).toBeGreaterThan(stepA);
+  });
+
+  it('fetchMockTimeseries сразу отказывает при abort', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      fetchMockTimeseries(
+        dispatch,
+        {
+          symbol: 'TEST',
+          timeframe: '1h',
+          limit: 5,
+        },
+        { signal: controller.signal },
+      ),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('searchMockSymbols сразу отказывает при abort', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      searchMockSymbols('btc', { signal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
   });
 });

--- a/apps/web/src/features/market-adapter/MarketAdapter.ts
+++ b/apps/web/src/features/market-adapter/MarketAdapter.ts
@@ -134,15 +134,10 @@ async function resolveProviderData(
   params: ProviderRequestBase,
   opts: AdapterCallOpts = {},
 ): Promise<ProviderResolveResult> {
-  const paramsWithSignal = {
-    ...params,
-    signal: opts.signal,
-  } as ProviderRequestBase & AdapterCallOpts;
-
   try {
     switch (provider) {
       case 'BINANCE': {
-        const klines = await fetchBinanceTimeseries(dispatch, paramsWithSignal);
+        const klines = await fetchBinanceTimeseries(dispatch, params, opts);
         return {
           ok: true,
           raw: klines,
@@ -152,7 +147,7 @@ async function resolveProviderData(
       }
 
       case 'MOEX': {
-        const moexRaw = await fetchMoexTimeseries(dispatch, paramsWithSignal);
+        const moexRaw = await fetchMoexTimeseries(dispatch, params, opts);
         return {
           ok: true,
           raw: moexRaw,
@@ -162,11 +157,7 @@ async function resolveProviderData(
       }
 
       case 'MOCK': {
-        const mockRaw = await fetchMockTimeseries(
-          dispatch,
-          paramsWithSignal,
-          opts,
-        );
+        const mockRaw = await fetchMockTimeseries(dispatch, params, opts);
         return {
           ok: true,
           raw: mockRaw,

--- a/apps/web/src/features/market-adapter/providers/BinanceProvider.ts
+++ b/apps/web/src/features/market-adapter/providers/BinanceProvider.ts
@@ -2,26 +2,74 @@
 import type { AppDispatch } from '@/shared/store';
 import { marketApi } from '@/shared/api/marketApi';
 import type { BinanceKline } from '@/shared/api/marketApi';
-import type { ProviderRequestBase } from './types';
+import type { ProviderCallOpts, ProviderRequestBase } from './types';
+
+function createAbortError(): Error {
+  const error = new Error('Aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+}
+
+function mapTimeframeToBinanceInterval(
+  timeframe: ProviderRequestBase['timeframe'],
+): string {
+  switch (timeframe) {
+    case '1h':
+      return '1h';
+    case '8h':
+      return '8h';
+    case '1d':
+      return '1d';
+    case '7d':
+      return '1w';
+    case '1mo':
+      return '1M';
+    default:
+      return timeframe;
+  }
+}
 
 export async function fetchBinanceTimeseries(
   dispatch: AppDispatch,
   params: ProviderRequestBase,
+  opts: ProviderCallOpts = {},
 ): Promise<BinanceKline[]> {
   const { symbol, timeframe, limit } = params;
+  const { signal } = opts;
+
+  throwIfAborted(signal);
+
+  const interval = mapTimeframeToBinanceInterval(timeframe);
 
   const queryResult = dispatch(
     marketApi.endpoints.getBinanceTimeseries.initiate({
       symbol,
-      interval: timeframe,
+      interval,
       limit,
     }),
   );
+
+  const onAbort = () => {
+    queryResult.abort();
+  };
+
+  if (signal) {
+    signal.addEventListener('abort', onAbort, { once: true });
+  }
 
   try {
     const data = await queryResult.unwrap();
     return data;
   } finally {
+    if (signal) {
+      signal.removeEventListener('abort', onAbort);
+    }
     // Отписка от запроса RTK Query
     queryResult.unsubscribe();
   }
@@ -34,7 +82,11 @@ export async function fetchBinanceTimeseries(
 export async function searchBinanceSymbols(
   dispatch: AppDispatch,
   query: string,
+  opts: ProviderCallOpts = {},
 ): Promise<unknown> {
+  const { signal } = opts;
+  throwIfAborted(signal);
+
   const q = query.trim();
   if (!q) return [];
 
@@ -42,9 +94,20 @@ export async function searchBinanceSymbols(
     marketApi.endpoints.searchBinanceSymbols.initiate(q),
   );
 
+  const onAbort = () => {
+    queryResult.abort();
+  };
+
+  if (signal) {
+    signal.addEventListener('abort', onAbort, { once: true });
+  }
+
   try {
     return await queryResult.unwrap();
   } finally {
+    if (signal) {
+      signal.removeEventListener('abort', onAbort);
+    }
     queryResult.unsubscribe();
   }
 }

--- a/apps/web/src/features/market-adapter/providers/types.ts
+++ b/apps/web/src/features/market-adapter/providers/types.ts
@@ -10,3 +10,7 @@ export interface ProviderRequestBase {
   timeframe: Timeframe;
   limit: number;
 }
+
+export type ProviderCallOpts = {
+  signal?: AbortSignal;
+};


### PR DESCRIPTION
# Providers

Providers: abort/cleanup + Binance timeframe mapping + тесты

## Связанные задачи
- Closes #112

## Тип изменений
- [x] Bug fix
- [ ] Feature
- [x] Refactor / Tech debt
- [ ] Docs / Chore
- [ ] CI/CD

## Что сделано
- Добавлен единый контракт opts.signal для провайдеров и обработка abort/cleanup в RTK Query.
- Реализован маппинг timeframe → Binance interval (7d -> 1w, 1mo -> 1M).
- Локальный MockProvider теперь уважает abort до генерации данных.
- Обновлены вызовы провайдеров в MarketAdapter под новый контракт.
- Дописаны unit-тесты на abort и маппинг timeframe для провайдеров.
