### PR TITLE
Поправил фильтр на History Page

### DIFF
--- a/apps/web/src/__tests__/features/history/HistorySearch.test.tsx
+++ b/apps/web/src/__tests__/features/history/HistorySearch.test.tsx
@@ -1,9 +1,24 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import HistorySearch from '@/features/history/HistorySearch';
 
 describe('HistorySearch', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const openFilters = () => {
+    const filterButton = screen.getByLabelText('Фильтры');
+    fireEvent.click(filterButton);
+  };
+
   it('calls searchAction when user types in input', () => {
     const searchAction = vi.fn();
 
@@ -33,5 +48,80 @@ describe('HistorySearch', () => {
     fireEvent.click(applyButton);
 
     expect(applyFiltersAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies selected provider, asset class, currency, and order', () => {
+    const searchAction = vi.fn();
+    const applyFiltersAction = vi.fn();
+
+    render(
+      <HistorySearch
+        searchAction={searchAction}
+        applyFiltersAction={applyFiltersAction}
+        currencyOptions={['USD']}
+      />,
+    );
+
+    openFilters();
+
+    fireEvent.click(screen.getByLabelText('BINANCE'));
+    fireEvent.click(screen.getByLabelText('CRYPTO'));
+    fireEvent.click(screen.getByLabelText('USD'));
+    fireEvent.click(screen.getByLabelText('Ascending order'));
+
+    fireEvent.click(screen.getByText('Apply'));
+
+    expect(applyFiltersAction).toHaveBeenCalledTimes(1);
+    expect(applyFiltersAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providers: expect.objectContaining({ binance: true }),
+        assetClasses: expect.objectContaining({ crypto: true }),
+        currencies: expect.objectContaining({ USD: true }),
+        order: 'asc',
+      }),
+    );
+  });
+
+  it('renders "No currencies" when currency options are empty', async () => {
+    const searchAction = vi.fn();
+    const applyFiltersAction = vi.fn();
+
+    const { rerender } = render(
+      <HistorySearch
+        searchAction={searchAction}
+        applyFiltersAction={applyFiltersAction}
+        currencyOptions={['USD']}
+      />,
+    );
+
+    openFilters();
+    expect(screen.getByLabelText('USD')).toBeInTheDocument();
+
+    rerender(
+      <HistorySearch
+        searchAction={searchAction}
+        applyFiltersAction={applyFiltersAction}
+        currencyOptions={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('No currencies')).toBeInTheDocument();
+    });
+  });
+
+  it('closes filters popover when clicking outside', () => {
+    const searchAction = vi.fn();
+
+    render(<HistorySearch searchAction={searchAction} />);
+
+    openFilters();
+    expect(screen.getByRole('dialog', { name: 'Filters' })).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+
+    expect(
+      screen.queryByRole('dialog', { name: 'Filters' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/history/page.tsx
+++ b/apps/web/src/app/history/page.tsx
@@ -1,32 +1,142 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import SearchBar from '@/features/history/HistorySearch';
+import SearchBar, {
+  type HistoryFilters,
+} from '@/features/history/HistorySearch';
 import HistoryTable from '@/features/history/HistoryTable';
 import { useHistory } from '@/entities/history/useHistory';
+import { MOCK_SYMBOLS } from '@/features/market-adapter/providers/MockProvider';
+
+const BINANCE_QUOTES = ['USDT', 'USDC', 'BUSD', 'USD', 'EUR', 'BTC', 'ETH'];
+
+const DEFAULT_FILTERS: HistoryFilters = {
+  providers: { binance: false, moex: false, mock: false },
+  assetClasses: {
+    equity: false,
+    fx: false,
+    crypto: false,
+    etf: false,
+    bond: false,
+    other: false,
+  },
+  currencies: {},
+  order: 'desc',
+};
+
+const inferBinanceCurrency = (symbol: string): string | undefined => {
+  const upper = symbol.toUpperCase();
+  return BINANCE_QUOTES.find((quote) => upper.endsWith(quote));
+};
+
+const inferMockMeta = (symbol: string) => {
+  const found = MOCK_SYMBOLS.find(
+    (item) => item.symbol.toLowerCase() === symbol.toLowerCase(),
+  );
+  if (!found) return {};
+  return {
+    assetClass: found.assetClass,
+    currency: found.currency,
+  };
+};
+
+const inferHistoryMeta = (entry: { symbol: string; provider: string }) => {
+  const provider = entry.provider.toLowerCase();
+  if (provider === 'binance') {
+    return {
+      assetClass: 'crypto',
+      currency: inferBinanceCurrency(entry.symbol),
+    };
+  }
+  if (provider === 'moex') {
+    return { assetClass: 'equity', currency: 'RUB' };
+  }
+  if (provider === 'mock') {
+    return inferMockMeta(entry.symbol);
+  }
+  return {};
+};
 
 export default function HistoryPage() {
   const [query, setQuery] = useState('');
+  const [filters, setFilters] = useState<HistoryFilters>(DEFAULT_FILTERS);
   const { items, loading, error } = useHistory();
 
   const handleSearch = (query: string) => {
     setQuery(query);
   };
 
+  const currencyOptions = useMemo(() => {
+    const currencies = new Set<string>();
+    items.forEach((item) => {
+      const meta = inferHistoryMeta(item);
+      if (meta.currency) {
+        currencies.add(meta.currency);
+      }
+    });
+    return Array.from(currencies).sort();
+  }, [items]);
+
   const filteredItems = useMemo(() => {
-    if (!query.trim()) return items;
-    const q = query.toLowerCase();
-    return items.filter(
-      (item) =>
-        item.symbol.toLowerCase().includes(q) ||
-        item.provider.toLowerCase().includes(q),
-    );
-  }, [items, query]);
+    const q = query.trim().toLowerCase();
+    const activeProviders = Object.entries(filters.providers)
+      .filter(([_, active]) => active)
+      .map(([provider]) => provider);
+    const activeClasses = Object.entries(filters.assetClasses)
+      .filter(([_, active]) => active)
+      .map(([assetClass]) => assetClass);
+    const activeCurrencies = Object.entries(filters.currencies)
+      .filter(([_, active]) => active)
+      .map(([currency]) => currency.toUpperCase());
+
+    const withFilters = items.filter((item) => {
+      const provider = item.provider.toLowerCase();
+      if (
+        q &&
+        !item.symbol.toLowerCase().includes(q) &&
+        !provider.includes(q)
+      ) {
+        return false;
+      }
+
+      if (activeProviders.length > 0 && !activeProviders.includes(provider)) {
+        return false;
+      }
+
+      const meta = inferHistoryMeta(item);
+      if (
+        activeClasses.length > 0 &&
+        (!meta.assetClass || !activeClasses.includes(meta.assetClass))
+      ) {
+        return false;
+      }
+
+      if (
+        activeCurrencies.length > 0 &&
+        (!meta.currency ||
+          !activeCurrencies.includes(meta.currency.toUpperCase()))
+      ) {
+        return false;
+      }
+
+      return true;
+    });
+
+    return withFilters.sort((a, b) => {
+      const aDate = Date.parse(a.created_at) || 0;
+      const bDate = Date.parse(b.created_at) || 0;
+      return filters.order === 'asc' ? aDate - bDate : bDate - aDate;
+    });
+  }, [items, query, filters]);
 
   return (
     <main className="history-page">
       <div className="search-bar-wrapper">
-        <SearchBar searchAction={handleSearch} />
+        <SearchBar
+          searchAction={handleSearch}
+          applyFiltersAction={setFilters}
+          currencyOptions={currencyOptions}
+        />
       </div>
 
       <div className="history-page-content">


### PR DESCRIPTION
# Шаблон Pull Request

<!-- Короткий заголовок PR: о чём изменение? -->

## Связанные задачи
- Closes #131

## Тип изменений
- [ ] Bug fix
- [X] Feature
- [X] Refactor / Tech debt
- [ ] Docs / Chore
- [ ] CI/CD

## Что сделано

- Обновил фильтры History Search: отдельные группы для биржи, assetClass и валюты, сортировка по Date.
- Добавил вычисление доступных валют и базовую классификацию assetClass/currency на History page для корректной фильтрации.
- Добавил нормализацию MOEX свечей в MarketAdapter и dev‑лог статистики.
- Привёл провайдеры к единому контракту с AbortSignal, корректным abort/unsubscribe и маппингом timeframe для Binance.
- Дописал unit‑тесты для HistorySearch (фильтры/валюты/закрытие поповера) и обновил тестовые моки.
