### PR TITLE
fix: set api port from .env on pnpm start

### DIFF
--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -56,7 +56,7 @@ function parseJwtExpiresIn(v: string | undefined): string {
 
 export function readEnv(processEnv: NodeJS.ProcessEnv = process.env): Env {
   const nodeEnv = parseNodeEnv(processEnv.NODE_ENV);
-  const port = parsePort(processEnv.PORT);
+  const port = parsePort(processEnv.PORT ?? processEnv.API_PORT);
   const corsOrigins = parseCorsOrigins(processEnv.CORS_ORIGINS, nodeEnv);
   const jwtSecret = parseJwtSecret(processEnv.JWT_SECRET, nodeEnv);
   const jwtExpiresIn = parseJwtExpiresIn(processEnv.JWT_EXPIRES_IN);

--- a/apps/api/src/config/loadEnv.ts
+++ b/apps/api/src/config/loadEnv.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function stripQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function findEnvPath(startDir: string): string | null {
+  let currentDir = startDir;
+  const { root } = path.parse(startDir);
+
+  while (true) {
+    const candidate = path.join(currentDir, '.env');
+    if (fs.existsSync(candidate)) return candidate;
+    if (currentDir === root) return null;
+    currentDir = path.dirname(currentDir);
+  }
+}
+
+export function loadEnv(envPath?: string) {
+  const resolvedPath = envPath ?? findEnvPath(process.cwd());
+  if (!resolvedPath) return;
+
+  const contents = fs.readFileSync(resolvedPath, 'utf8');
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const equalsIndex = line.indexOf('=');
+    if (equalsIndex === -1) continue;
+
+    const key = line.slice(0, equalsIndex).trim();
+    const value = stripQuotes(line.slice(equalsIndex + 1).trim());
+
+    if (key && process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import { pathToFileURL } from 'node:url';
 import { mkdirSync } from 'node:fs';
 
 import { readEnv } from './config/env.js';
+import { loadEnv } from './config/loadEnv.js';
 import { MAX_AVATAR_SIZE, uploadRoot } from './config/uploads.js';
 import { buildLoggerOptions } from './infra/logger.js';
 import { registerErrorHandler } from './infra/errorHandler.js';
@@ -15,6 +16,7 @@ import { registerRouter } from './http/router.js';
 import { checkDbConnection } from './db/index.js';
 
 export function buildApp() {
+  loadEnv();
   const env = readEnv();
 
   const app = Fastify({


### PR DESCRIPTION
при запуске pnpm dev/start порт для api теперь берётся из .env

теперь доступен быстрый запуск:
- через докер запустить только бд
- через pnpm dev / pnpm build + start в корне запустить api + web